### PR TITLE
Fix sending HTTP status code and description in responses

### DIFF
--- a/Sources/Swiftra.swift
+++ b/Sources/Swiftra.swift
@@ -63,7 +63,7 @@ public func serve(port: UInt16) {
             response!.body = Response.Status.NotFound.description.bytes()
         }
         let size = response!.body.filter({ c in return c != 0 }).count
-        try writer.write("HTTP/1.0 \(response!.status) \(response!.status.description)\r\n")
+        try writer.write("HTTP/1.0 \(response!.status.rawValue) \(response!.status)\r\n")
         try writer.write("Content-Length: \(size)\r\n")
         for header in response!.headers {
             try writer.write("\(header.0): \(header.1)\r\n")


### PR DESCRIPTION
I discovered that Swiftra was sending initial response lines that look like:

```
HTTP/1.0 OK OK
```

This fixes the behavior so they come back like:

```
HTTP/1.0 200 OK
```
