### PR TITLE
http4swiftを最新にしたい

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,6 @@ let package = Package(
     name: "swiftra",
     dependencies: [
         .Package(url: "https://github.com/nestproject/Nest.git", majorVersion: 0, minor: 2),
-        .Package(url: "https://github.com/takebayashi/http4swift.git", majorVersion: 0, minor: 2)
+        .Package(url: "https://github.com/takebayashi/http4swift.git", majorVersion: 0, minor: 4)
     ]
 )


### PR DESCRIPTION
error: 'memory' has been renamed to 'pointee'などのエラー発生
